### PR TITLE
Specify `__all__` in `__init__.py` to satisfy pyright

### DIFF
--- a/html_text/__init__.py
+++ b/html_text/__init__.py
@@ -10,3 +10,14 @@ from .html_text import (
     parse_html,
     selector_to_text,
 )
+
+__all__ = (
+    "DOUBLE_NEWLINE_TAGS",
+    "NEWLINE_TAGS",
+    "cleaned_selector",
+    "cleaner",
+    "etree_to_text",
+    "extract_text",
+    "parse_html",
+    "selector_to_text",
+)

--- a/tox.ini
+++ b/tox.ini
@@ -37,4 +37,4 @@ deps =
     pytest
     types-lxml==2024.12.13
 commands =
-    mypy --strict --implicit-reexport {posargs: html_text tests}
+    mypy --strict {posargs: html_text tests}


### PR DESCRIPTION
- In #17

The `py.typed` was added, but you didn't define __all__ in __init__.py. As a result, Pyright is throwing an [error](https://github.com/promplate/reasonify/actions/runs/13262331168/job/37441266947?pr=108#step:8:9):

```sh
Error: "extract_text" is not exported from module "html_text"
  Import from "html_text.html_text" instead (reportPrivateImportUsage)
```

By default, [Pyright treats imported symbols as private](https://microsoft.github.io/pyright/#/typed-libraries?id=library-interface) unless they are explicitly re-exported, for example, with `from .html_text import parse_html as parse_html`. This means we need to explicitly declare `__all__` to make them public.

Honestly, I find this a bit redundant in most cases 😂
